### PR TITLE
chore: update version references in component and main files

### DIFF
--- a/components/cloud-provider-onmetal/component-descriptor.yaml
+++ b/components/cloud-provider-onmetal/component-descriptor.yaml
@@ -8,7 +8,7 @@ component:
   resources: []
   sources:
   - access:
-      ref: refs/tags/0.1.5
+      ref: refs/tags/v0.1.5
       repoUrl: github.com/onmetal/cloud-provider-onmetal
       type: github
     labels:
@@ -17,7 +17,7 @@ component:
         repository-classification: main
     name: github_com_onmetal_cloud_provider_onmetal
     type: git
-    version: 0.1.5
-  version: 0.1.5
+    version: v0.1.5
+  version: v0.1.5
 meta:
   schemaVersion: v2

--- a/components/gardener-extension-provider-onmetal/component-descriptor.yaml
+++ b/components/gardener-extension-provider-onmetal/component-descriptor.yaml
@@ -8,7 +8,7 @@ component:
   resources: []
   sources:
   - access:
-      ref: refs/tags/0.1.7
+      ref: refs/tags/v0.1.7
       repoUrl: github.com/onmetal/gardener-extension-provider-onmetal
       type: github
     labels:
@@ -17,7 +17,7 @@ component:
         repository-classification: main
     name: github_com_onmetal_gardener_extension_provider_onmetal
     type: git
-    version: 0.1.7
-  version: 0.1.7
+    version: v0.1.7
+  version: v0.1.7
 meta:
   schemaVersion: v2

--- a/components/machine-controller-manager-provider-onmetal/component-descriptor.yaml
+++ b/components/machine-controller-manager-provider-onmetal/component-descriptor.yaml
@@ -8,7 +8,7 @@ component:
   resources: []
   sources:
   - access:
-      ref: refs/tags/0.1.5
+      ref: refs/tags/v0.1.5
       repoUrl: github.com/onmetal/machine-controller-manager-provider-onmetal
       type: github
     labels:
@@ -17,7 +17,7 @@ component:
         repository-classification: main
     name: github_com_onmetal_machine_controller_manager_provider_onmetal
     type: git
-    version: 0.1.5
-  version: 0.1.5
+    version: v0.1.5
+  version: v0.1.5
 meta:
   schemaVersion: v2

--- a/components/onmetal-csi-driver/component-descriptor.yaml
+++ b/components/onmetal-csi-driver/component-descriptor.yaml
@@ -8,7 +8,7 @@ component:
   resources: []
   sources:
   - access:
-      ref: refs/tags/0.1.5
+      ref: refs/tags/v0.1.5
       repoUrl: github.com/onmetal/onmetal-csi-driver
       type: github
     labels:
@@ -17,7 +17,7 @@ component:
         repository-classification: main
     name: github_com_onmetal_onmetal_csi_driver
     type: git
-    version: 0.1.5
-  version: 0.1.5
+    version: v0.1.5
+  version: v0.1.5
 meta:
   schemaVersion: v2

--- a/ocm-updater/main.go
+++ b/ocm-updater/main.go
@@ -130,7 +130,7 @@ func updateComponentDescriptor(ctx context.Context, log logr.Logger, gitResolver
 				log.Info("Found new version")
 			}
 			s.Version = latest
-			access.Ref = fmt.Sprintf("refs/tags/%s", latest)
+			access.Ref = fmt.Sprintf("refs/tags/v%s", latest)
 			newAccess, err := v2.NewUnstructured(access)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create new unstructured access object: %w", err)


### PR DESCRIPTION
- Update the version reference in `components/cloud-provider-onmetal/component-descriptor.yaml` from `0.1.5` to `v0.1.5`
- Update the version reference in `components/gardener-extension-provider-onmetal/component-descriptor.yaml` from `0.1.7` to `v0.1.7`
- Update the version reference in `components/machine-controller-manager-provider-onmetal/component-descriptor.yaml` from `0.1.5` to `v0.1.5`
- Update the version reference in `components/onmetal-csi-driver/component-descriptor.yaml` from `0.1.5` to `v0.1.5`
- Update the version reference in `ocm-updater/main.go` from `refs/tags/%s` to `refs/tags/v%s`