### PR TITLE
Update version string format and access.Ref value

### DIFF
--- a/ocm-updater/main.go
+++ b/ocm-updater/main.go
@@ -129,7 +129,7 @@ func updateComponentDescriptor(ctx context.Context, log logr.Logger, gitResolver
 			if s.Version != latest {
 				log.Info("Found new version")
 			}
-			s.Version = latest
+			s.Version = fmt.Sprintf("v%s", latest)
 			access.Ref = fmt.Sprintf("refs/tags/v%s", latest)
 			newAccess, err := v2.NewUnstructured(access)
 			if err != nil {
@@ -139,10 +139,11 @@ func updateComponentDescriptor(ctx context.Context, log logr.Logger, gitResolver
 			*s.Access = newAccess
 
 			if access.RepoURL == desc.Name {
-				if desc.Version != latest {
+				latestVersion := fmt.Sprintf("v%s", latest)
+				if desc.Version != latestVersion {
 					log.Info("Updating component descriptor version")
 				}
-				desc.Version = latest
+				desc.Version = latestVersion
 			}
 		default:
 			return nil, fmt.Errorf("access type not supported")


### PR DESCRIPTION
- Modify the version string format to include the prefix "v"
- Update the access.Ref value to include the prefix "refs/tags/"
- Modify the condition for updating the component descriptor version to compare with the new format